### PR TITLE
Return reads from FASTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ fn main() {
 
 
     // Read
-    let read = store.read(key);
+    let (status, recv) = store.read(key);
     assert_eq!(read, status::OK);
+    assert_eq!(recv.recv().unwrap(), value);
 
     let bad_key: u64 = 2;
     let bad_read = store.read(bad_key);
@@ -44,7 +45,7 @@ fn main() {
 
 # Things to fix
 
-- [ ] Fix so you can actually return the values from read
+- [x] Fix so you can actually return the values from read
 - [ ] Experiment with #repr(C) structs for values rather than u64
 - [ ] Look into threading and async callbacks into Rust
 - [ ] Finish off the rest off the operations in the C interface

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,19 @@ use std::ffi::CString;
 use std::ffi::CStr;
 use std::fs;
 use std::io;
+use std::sync::mpsc::{channel, Sender, Receiver};
 
 pub mod status;
 pub mod util;
 use self::util::*;
+
+extern fn read_callback(sender: *mut libc::c_void, value: u64, status: u32) {
+    let boxed_sender = unsafe {Box::from_raw(sender as *mut Sender<u64>)};
+    let sender = *boxed_sender;
+    if status == status::OK.into() {
+        sender.send(value).unwrap();
+    }
+}
 
 pub struct FasterKv {
     faster_t: *mut ffi::faster_t,
@@ -35,10 +44,14 @@ impl FasterKv {
         }
     }
 
-    pub fn read(&self, key: u64) -> u8 {
+    pub fn read(&self, key: u64) -> (u8, Receiver<u64>) {
+        let (sender, receiver) = channel();
+        let sender_ptr: *mut Sender<u64> = Box::into_raw(Box::new(sender));
+        let status;
         unsafe {
-            ffi::faster_read(self.faster_t, key)
+            status = ffi::faster_read(self.faster_t, key, Some(read_callback), sender_ptr as *mut libc::c_void);
         }
+        (status, receiver)
     }
 
     pub fn rmw(&self, key: u64, value: u64) -> u8 {
@@ -178,12 +191,6 @@ mod tests {
             let upsert = store.upsert(key, value);
             assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-            let res = store.read(key);
-            assert!(res == status::OK);
-
-            let res = store.read(2 as u64);
-            assert!(res == status::NOT_FOUND);
-
             let rmw = store.rmw(key, 5 as u64);
             assert!(rmw == status::OK);
 
@@ -195,6 +202,42 @@ mod tests {
             }
         } else {
             assert!(false)
+        }
+    }
+
+    #[test]
+    fn faster_read_inserted_value() {
+        if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage1")) {
+            let key: u64 = 1;
+            let value: u64 = 1337;
+
+            let upsert = store.upsert(key, value);
+            assert!((upsert == status::OK || upsert == status::PENDING) == true);
+
+            let (res, recv) = store.read(key);
+            assert!(res == status::OK);
+            assert!(recv.recv().unwrap() == value);
+
+            match store.clean_storage() {
+                Ok(()) => assert!(true),
+                Err(_err) => assert!(false)
+            }
+        }
+    }
+
+    #[test]
+    fn faster_read_missing_value_recv_error() {
+        if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage2")) {
+            let key: u64 = 1;
+
+            let (res, recv) = store.read(key);
+            assert!(res == status::NOT_FOUND);
+            assert!(recv.recv().is_err());
+
+            match store.clean_storage() {
+                Ok(()) => assert!(true),
+                Err(_err) => assert!(false)
+            }
         }
     }
 }


### PR DESCRIPTION
What: return values read from FASTER via an `mpsc` channel

Why: need to be able to read values and using a channel simplifies processing for user. They can block on channel or process asynchronously.

Caveat: not sure what happens when the read is processed asynchronously (due to fetching from disc)