### PR TITLE
Add test for rmw without upsert

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,4 +270,24 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn faster_rmw_without_upsert() {
+        if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage4")) {
+            let key: u64 = 1;
+            let modification: u64 = 100;
+
+            let rmw = store.rmw(key, modification);
+            assert!((rmw == status::OK || rmw == status::PENDING) == true);
+
+            let (res, recv) = store.read(key);
+            assert!(res == status::OK);
+            assert!(recv.recv().unwrap() == modification);
+
+            match store.clean_storage() {
+                Ok(()) => assert!(true),
+                Err(_err) => assert!(false)
+            }
+        }
+    }
 }


### PR DESCRIPTION
What: Added a test to show that RMW uses the supplied modification as the initial value if called before key has been been upserted into FASTER

Why: I added the test whilst working on something else and think it's helpful to demonstrate RMW capability