### PR TITLE
Support arbitrary values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "faster_kvs"
 version = "0.1.0"
-authors = ["Max Meldrum <mmeldrum@kth.se>"]
+authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 keywords = ["concurrent", "embedded", "key-value-store"]
 description = "Rust wrapper for FASTER by Microsoft Research"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 
 
 [dependencies]
+bincode = "1.1.2"
 libc = "0.2"
 libfaster-sys = { path = "libfaster-sys", version = "0.1.0" }
+serde = "1.0.89"
+serde_derive = "1.0.89"
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,125 @@
 # Experimental FASTER wrapper for Rust
 
-Includes experimental C interface for FASTER. It currently assumes the KEY,VALUE types are u64. This wrapper is only focusing on Linux support. 
+Includes experimental C interface for FASTER. It currently assumes the KEY type is u64 however the VALUE type supports arbitrary serialisable structs. This wrapper is only focusing on Linux support.
 
 
 It is probably a good idea to make sure you can compile the C++ version before you start playing around with this wrapper.
 
+*Make sure you clone the submodules as well*, this is best done by cloning with `git clone --recurse-submodules`.
 
-Down below are some example operations. 
+
+## A basic example
+
+The following example shows the creation of a FASTER Key-Value Store and basic operations on `u64` values.
+
+Try it out by running `cargo run --example basic`.
 
 ```rust,no_run
 extern crate faster_kvs;
 
-use faster_kvs::*;
-
-const TABLE_SIZE: u64  = 1 << 14;
-const LOG_SIZE: u64 = 17179869184;
+use faster_kvs::{FasterKv, status};
+use std::sync::mpsc::Receiver;
 
 fn main() {
-  if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage_dir")) {
-    let key: u64 = 1;
-    let value: u64 = 1000;
+    const TABLE_SIZE: u64  = 1 << 14;
+    const LOG_SIZE: u64 = 17179869184;
 
-    // Upsert
-    store.upsert(key, value);
+    // Create a Key-Value Store
+    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("example_basic_storage")) {
+        let key0: u64 = 1;
+        let value0: u64 = 1000;
+        let modification: u64 = 5;
 
-    // Read-Modify-Write
-    let incr: u64 = 50;
-    let rmw = store.rmw(key, incr);
-    assert_eq!(rmw, status::OK);
+        // Upsert
+        for i in 0..1000 {
+            let upsert = store.upsert(key0 + i, &(value0 + i));
+            assert!(upsert == status::OK || upsert == status::PENDING);
+        }
 
-    // Read
-    let (status, recv) = store.read(key);
-    assert_eq!(status, status::OK);
-    assert_eq!(recv.recv().unwrap(), value + incr);
+        // Read-Modify-Write
+        for i in 0..1000 {
+            let rmw = store.rmw(key0 + i, &(5 as u64));
+            assert!(rmw == status::OK || rmw == status::PENDING);
+        }
 
-    let bad_key: u64 = 2;
-    let (status, recv) = store.read(bad_key);
-    assert_eq!(status, status::NOT_FOUND);
-  }
+        assert!(store.size() > 0);
+
+        // Read
+        for i in 0..1000 {
+            // Note: need to provide type annotation for the Receiver
+            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i);
+            assert!(read == status::OK || read == status::PENDING);
+            let val = recv.recv().unwrap();
+            assert_eq!(val, value0 + i + modification);
+            println!("Key: {}, Value: {}", key0 + i, val);
+        }
+
+        // Clear used storage
+        match store.clean_storage() {
+            Ok(()) => {},
+            Err(_err) => panic!("Unable to clear FASTER directory"),
+        }
+    } else {
+        panic!("Unable to create FASTER directory");
+    }
+}
+```
+
+## Using custom values
+`struct`s that can be (de)serialised using [serde](https://crates.rs/crates/serde) are supported as values. In order to use such a `struct`, it is necessary to derive the implementations of `Serializable` and `Deserializable` from `serde-derive`. It is also necessary to implement the `FasterValue` trait which exposes an `rmw()` function. This function can be used to implement custom logic for Read-Modify-Write operations or simply left with an `unimplemented!()` macro. In the latter case, any attempt to invoke a RMW operation will cause a panic.
+
+The following example shows a basic struct being used as a value. Try it out by running `cargo run --example custom_values`.
+
+```rust,no_run
+extern crate faster_kvs;
+extern crate serde_derive;
+
+use faster_kvs::{FasterKv, FasterValue,status};
+use serde_derive::{Deserialize, Serialize};
+use std::sync::mpsc::Receiver;
+
+// Note: Debug annotation is just for printing later
+#[derive(Serialize, Deserialize, Debug)]
+struct MyValue {
+    foo: String,
+    bar: String,
+}
+
+impl FasterValue<'_, MyValue> for MyValue {
+    fn rmw(&self, modification: MyValue) -> MyValue {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    const TABLE_SIZE: u64  = 1 << 14;
+    const LOG_SIZE: u64 = 17179869184;
+
+    // Create a Key-Value Store
+    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("example_custom_values_storage")) {
+        let key: u64 = 1;
+        let value = MyValue { foo: String::from("Hello"), bar: String::from("World") };
+
+        // Upsert
+        let upsert = store.upsert(key, &value);
+        assert!(upsert == status::OK || upsert == status::PENDING);
+
+        assert!(store.size() > 0);
+
+        // Note: need to provide type annotation for the Receiver
+        let (read, recv): (u8, Receiver<MyValue>) = store.read(key);
+        assert!(read == status::OK || read == status::PENDING);
+        let val = recv.recv().unwrap();
+        println!("Key: {}, Value: {:?}", key, val);
+
+        // Clear used storage
+        match store.clean_storage() {
+            Ok(()) => {},
+            Err(_err) => panic!("Unable to clear FASTER directory"),
+        }
+    } else {
+        panic!("Unable to create FASTER directory");
+    }
 }
 ```
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,48 @@
+extern crate faster_kvs;
+
+use faster_kvs::{FasterKv, status};
+use std::sync::mpsc::Receiver;
+
+fn main() {
+    const TABLE_SIZE: u64  = 1 << 14;
+    const LOG_SIZE: u64 = 17179869184;
+
+    // Create a Key-Value Store
+    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("example_basic_storage")) {
+        let key0: u64 = 1;
+        let value0: u64 = 1000;
+        let modification: u64 = 5;
+
+        // Upsert
+        for i in 0..1000 {
+            let upsert = store.upsert(key0 + i, &(value0 + i));
+            assert!(upsert == status::OK || upsert == status::PENDING);
+        }
+
+        // Read-Modify-Write
+        for i in 0..1000 {
+            let rmw = store.rmw(key0 + i, &(5 as u64));
+            assert!(rmw == status::OK || rmw == status::PENDING);
+        }
+
+        assert!(store.size() > 0);
+
+        // Read
+        for i in 0..1000 {
+            // Note: need to provide type annotation for the Receiver
+            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i);
+            assert!(read == status::OK || read == status::PENDING);
+            let val = recv.recv().unwrap();
+            assert_eq!(val, value0 + i + modification);
+            println!("Key: {}, Value: {}", key0 + i, val);
+        }
+
+        // Clear used storage
+        match store.clean_storage() {
+            Ok(()) => {},
+            Err(_err) => panic!("Unable to clear FASTER directory"),
+        }
+    } else {
+        panic!("Unable to create FASTER directory");
+    }
+}

--- a/examples/custom_values.rs
+++ b/examples/custom_values.rs
@@ -1,0 +1,50 @@
+extern crate faster_kvs;
+extern crate serde_derive;
+
+use faster_kvs::{FasterKv, FasterValue,status};
+use serde_derive::{Deserialize, Serialize};
+use std::sync::mpsc::Receiver;
+
+// Note: Debug annotation is just for printing later
+#[derive(Serialize, Deserialize, Debug)]
+struct MyValue {
+    foo: String,
+    bar: String,
+}
+
+impl FasterValue<'_, MyValue> for MyValue {
+    fn rmw(&self, modification: MyValue) -> MyValue {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    const TABLE_SIZE: u64  = 1 << 14;
+    const LOG_SIZE: u64 = 17179869184;
+
+    // Create a Key-Value Store
+    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("example_custom_values_storage")) {
+        let key: u64 = 1;
+        let value = MyValue { foo: String::from("Hello"), bar: String::from("World") };
+
+        // Upsert
+        let upsert = store.upsert(key, &value);
+        assert!(upsert == status::OK || upsert == status::PENDING);
+
+        assert!(store.size() > 0);
+
+        // Note: need to provide type annotation for the Receiver
+        let (read, recv): (u8, Receiver<MyValue>) = store.read(key);
+        assert!(read == status::OK || read == status::PENDING);
+        let val = recv.recv().unwrap();
+        println!("Key: {}, Value: {:?}", key, val);
+
+        // Clear used storage
+        match store.clean_storage() {
+            Ok(()) => {},
+            Err(_err) => panic!("Unable to clear FASTER directory"),
+        }
+    } else {
+        panic!("Unable to create FASTER directory");
+    }
+}

--- a/libfaster-sys/Cargo.toml
+++ b/libfaster-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libfaster-sys"
 description = "Bindings for FASTER"
 version = "0.1.0"
-authors = ["Max Meldrum <mmeldrum@kth.se>"]
+authors = ["Max Meldrum <mmeldrum@kth.se>", "Matthew Brookes <mbrookes1304@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/Max-Meldrum/faster-rs.git"
 keywords = [ "FASTER", "ffi", "experimental" ]

--- a/src/faster_value.rs
+++ b/src/faster_value.rs
@@ -1,0 +1,60 @@
+extern crate bincode;
+extern crate libc;
+extern crate libfaster_sys as ffi;
+
+use crate::status;
+
+use bincode::deserialize;
+use serde::{Deserialize, Serialize};
+use std::mem;
+use std::sync::mpsc::Sender;
+
+pub trait FasterValue<'a, T: Deserialize<'a> + Serialize + FasterValue<'a, T>> {
+    extern fn read_callback(sender: *mut libc::c_void, value: *mut u8, length: u64, status: u32) {
+        let boxed_sender = unsafe {Box::from_raw(sender as *mut Sender<T>)};
+        let sender = *boxed_sender;
+        if status == status::OK.into() {
+            let slice = unsafe {
+                deserialize(std::slice::from_raw_parts_mut(value, length as usize)).unwrap()
+            };
+            sender.send(slice).unwrap();
+        }
+    }
+
+    extern fn rmw_callback(
+        value: *mut u8,
+        modification: *mut u8,
+        length_value: u64,
+        length_modification: u64
+    ) -> ffi::faster_rmw_result {
+        let val: T = unsafe {
+            deserialize(std::slice::from_raw_parts_mut(value, length_value as usize)).unwrap()
+        };
+        let modif = unsafe {
+            deserialize(std::slice::from_raw_parts_mut(modification, length_modification as usize)).unwrap()
+        };
+        let modified = val.rmw(modif);
+        let mut encoded = bincode::serialize(&modified).unwrap();
+        let ptr = encoded.as_mut_ptr();
+        let size = encoded.len();
+        mem::forget(encoded);
+        ffi::faster_rmw_result {
+            value: ptr,
+            size: size as u64,
+        }
+    }
+
+    fn rmw(&self, modification: T) -> T;
+}
+
+impl <'a> FasterValue<'a, String> for String {
+    fn rmw(&self, modification: String) -> String {
+        unimplemented!()
+    }
+}
+
+impl <'a> FasterValue<'a, u64> for u64 {
+    fn rmw(&self, modification: u64) -> u64 {
+        self + modification
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,20 @@
+extern crate bincode;
 extern crate libc;
 extern crate libfaster_sys as ffi;
 
+pub mod status;
+pub mod util;
+pub mod faster_value;
 
-use std::ffi::CString;
+use crate::util::*;
+pub use crate::faster_value::FasterValue;
+
+use serde::{Serialize, Deserialize};
 use std::ffi::CStr;
+use std::ffi::CString;
 use std::fs;
 use std::io;
 use std::sync::mpsc::{channel, Sender, Receiver};
-
-pub mod status;
-pub mod util;
-use self::util::*;
-
-extern fn read_callback(sender: *mut libc::c_void, value: u64, status: u32) {
-    let boxed_sender = unsafe {Box::from_raw(sender as *mut Sender<u64>)};
-    let sender = *boxed_sender;
-    if status == status::OK.into() {
-        sender.send(value).unwrap();
-    }
-}
 
 pub struct FasterKv {
     faster_t: *mut ffi::faster_t,
@@ -38,24 +34,26 @@ impl FasterKv {
         Ok(FasterKv { faster_t: faster_t, storage_dir: saved_dir })
     }
 
-    pub fn upsert(&self, key: u64, value: u64) -> u8 {
+    pub fn upsert<T: Serialize>(&self, key: u64, value: &T) -> u8 {
+        let mut encoded = bincode::serialize(value).unwrap();
         unsafe {
-            ffi::faster_upsert(self.faster_t, key, value)
+            ffi::faster_upsert(self.faster_t, key, encoded.as_mut_ptr(), encoded.len() as u64)
         }
     }
 
-    pub fn read(&self, key: u64) -> (u8, Receiver<u64>) {
+    pub fn read<'a, T: FasterValue<'a, T> + Deserialize<'a> + Serialize>(&'a self, key: u64) -> (u8, Receiver<T>) {
         let (sender, receiver) = channel();
-        let sender_ptr: *mut Sender<u64> = Box::into_raw(Box::new(sender));
+        let sender_ptr: *mut Sender<T> = Box::into_raw(Box::new(sender));
         let status = unsafe {
-            ffi::faster_read(self.faster_t, key, Some(read_callback), sender_ptr as *mut libc::c_void)
+            ffi::faster_read(self.faster_t, key, Some(T::read_callback), sender_ptr as *mut libc::c_void)
         };
         (status, receiver)
     }
 
-    pub fn rmw(&self, key: u64, value: u64) -> u8 {
+    pub fn rmw<'a, T: FasterValue<'a, T> + Deserialize<'a> + Serialize>(&'a self, key: u64, value: &T) -> u8 {
+        let mut encoded = bincode::serialize(value).unwrap();
         unsafe {
-            ffi::faster_rmw(self.faster_t, key, value)
+            ffi::faster_rmw(self.faster_t, key, encoded.as_mut_ptr(), encoded.len() as u64, Some(T::rmw_callback))
         }
     }
 
@@ -190,10 +188,10 @@ mod tests {
             let key: u64 = 1;
             let value: u64 = 1337;
 
-            let upsert = store.upsert(key, value);
+            let upsert = store.upsert(key, &value);
             assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-            let rmw = store.rmw(key, 5 as u64);
+            let rmw = store.rmw(key, &(5 as u64));
             assert!(rmw == status::OK);
 
             assert!(store.size() > 0);
@@ -213,10 +211,10 @@ mod tests {
             let key: u64 = 1;
             let value: u64 = 1337;
 
-            let upsert = store.upsert(key, value);
+            let upsert = store.upsert(key, &value);
             assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-            let (res, recv) = store.read(key);
+            let (res, recv): (u8, Receiver<u64>) = store.read(key);
             assert!(res == status::OK);
             assert!(recv.recv().unwrap() == value);
 
@@ -232,7 +230,7 @@ mod tests {
         if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage2")) {
             let key: u64 = 1;
 
-            let (res, recv) = store.read(key);
+            let (res, recv): (u8, Receiver<u64>) = store.read(key);
             assert!(res == status::NOT_FOUND);
             assert!(recv.recv().is_err());
 
@@ -250,17 +248,17 @@ mod tests {
             let value: u64 = 1337;
             let modification: u64 = 100;
 
-            let upsert = store.upsert(key, value);
+            let upsert = store.upsert(key, &value);
             assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-            let (res, recv) = store.read(key);
+            let (res, recv): (u8, Receiver<u64>) = store.read(key);
             assert!(res == status::OK);
             assert!(recv.recv().unwrap() == value);
 
-            let rmw = store.rmw(key, modification);
+            let rmw = store.rmw(key, &modification);
             assert!((rmw == status::OK || rmw == status::PENDING) == true);
 
-            let (res, recv) = store.read(key);
+            let (res, recv): (u8, Receiver<u64>) = store.read(key);
             assert!(res == status::OK);
             assert!(recv.recv().unwrap() == value + modification);
 
@@ -277,10 +275,10 @@ mod tests {
             let key: u64 = 1;
             let modification: u64 = 100;
 
-            let rmw = store.rmw(key, modification);
+            let rmw = store.rmw(key, &modification);
             assert!((rmw == status::OK || rmw == status::PENDING) == true);
 
-            let (res, recv) = store.read(key);
+            let (res, recv): (u8, Receiver<u64>) = store.read(key);
             assert!(res == status::OK);
             assert!(recv.recv().unwrap() == modification);
 

--- a/tests/checkpoint_test.rs
+++ b/tests/checkpoint_test.rs
@@ -10,7 +10,7 @@ fn single_checkpoint() {
         let value: u64 = 100;
 
         for key in 0..1000 {
-            store.upsert(key as u64, value);
+            store.upsert(key as u64, &value);
         }
 
         let checkpoint = store.checkpoint().unwrap();

--- a/tests/thread_operations_test.rs
+++ b/tests/thread_operations_test.rs
@@ -3,6 +3,7 @@ extern crate faster_kvs;
 use faster_kvs::FasterKv;
 use std::thread;
 use std::sync::Arc;
+use std::sync::mpsc::Receiver;
 
 #[test]
 fn multi_threaded_test() {
@@ -15,7 +16,7 @@ fn multi_threaded_test() {
     let modification: u64 = 30;
 
     for key in 0..ops {
-        store.upsert(key as u64, initial_value);
+        store.upsert(key as u64, &initial_value);
     }
 
     let num_threads = 4;
@@ -27,7 +28,7 @@ fn multi_threaded_test() {
             let session = store.start_session();
 
             for key in 0..ops {
-                store.rmw(key as u64, modification);
+                store.rmw(key as u64, &modification);
             }
 
             // Make sure everything is completed
@@ -44,7 +45,7 @@ fn multi_threaded_test() {
 
     for key in 0..ops {
         let expected_value = initial_value + (modification * num_threads);
-        let (res, recv) = store.read(key as u64);
+        let (res, recv): (u8, Receiver<u64>) = store.read(key as u64);
         assert_eq!(recv.recv().unwrap(), expected_value);
     }
 


### PR DESCRIPTION
What:
* allow users to specify their own structs to be stored as values in FASTER
* allow users to provide their own RMW logic
* provide out-of-the-box implementations of above for `u64`s and `String`s (need to find better way of providing this for other standard types)
* add stand-alone examples
* update README
* add my name to author's list

Why:
* many obvious reasons why a user would want more than just u64s
* user defining RMW logic makes things easier for us
* examples and README help users
* I did some authoring :)

Closes: #5 