### PR TITLE
Require monotonic serial number for persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ It is probably a good idea to make sure you can compile the C++ version before y
 
 *Make sure you clone the submodules as well*, this is best done by cloning with `git clone --recurse-submodules`.
 
+## The interface
+This wrapper attempts to remain true to the original FASTER design by exposing a similar interface to that which is provided by the original C++ version. Users may define their own value types (that implement the `FasterValue` trait) and provide custom logic for Read-Modify-Write operations.
+
+
+The `Read`, `Upsert` and `RMW` operations all require a monotonic serial number to form the sequence of operations that will be persisted by FASTER. `Read` operations require a serial number so that at a CPR checkpoint boundary, FASTER guarantees that the reads before that point have accessed no data updates after the checkpoint. If persistence is not important, the serial number can safely be set to `1` for all operations (as is done in the examples above).
+
+More information about Checkpointing and Recovery is provided below the following examples.
 
 ## A basic example
 
@@ -32,13 +39,13 @@ fn main() {
 
         // Upsert
         for i in 0..1000 {
-            let upsert = store.upsert(key0 + i, &(value0 + i));
+            let upsert = store.upsert(key0 + i, &(value0 + i), i);
             assert!(upsert == status::OK || upsert == status::PENDING);
         }
 
         // Read-Modify-Write
         for i in 0..1000 {
-            let rmw = store.rmw(key0 + i, &(5 as u64));
+            let rmw = store.rmw(key0 + i, &(5 as u64), i + 1000);
             assert!(rmw == status::OK || rmw == status::PENDING);
         }
 
@@ -47,7 +54,7 @@ fn main() {
         // Read
         for i in 0..1000 {
             // Note: need to provide type annotation for the Receiver
-            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i);
+            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i, i);
             assert!(read == status::OK || read == status::PENDING);
             let val = recv.recv().unwrap();
             assert_eq!(val, value0 + i + modification);
@@ -86,7 +93,7 @@ struct MyValue {
 }
 
 impl FasterValue<'_, MyValue> for MyValue {
-    fn rmw(&self, modification: MyValue) -> MyValue {
+    fn rmw(&self, _modification: MyValue) -> MyValue {
         unimplemented!()
     }
 }
@@ -101,13 +108,13 @@ fn main() {
         let value = MyValue { foo: String::from("Hello"), bar: String::from("World") };
 
         // Upsert
-        let upsert = store.upsert(key, &value);
+        let upsert = store.upsert(key, &value, 1);
         assert!(upsert == status::OK || upsert == status::PENDING);
 
         assert!(store.size() > 0);
 
         // Note: need to provide type annotation for the Receiver
-        let (read, recv): (u8, Receiver<MyValue>) = store.read(key);
+        let (read, recv): (u8, Receiver<MyValue>) = store.read(key, 1);
         assert!(read == status::OK || read == status::PENDING);
         let val = recv.recv().unwrap();
         println!("Key: {}, Value: {:?}", key, val);
@@ -129,6 +136,19 @@ Several types already implement `FasterValue` along with providing Read-Modify-W
 * Bools and Chars replace old value for new value
 * Strings and Vectors append new values (use an `upsert` to replace entire value)
 
+## Checkpoint and Recovery
+FASTER's fault tolerance is provided by [Concurrent Prefix Recovery](https://www.microsoft.com/en-us/research/uploads/prod/2019/01/cpr-sigmod19.pdf) (CPR). It provides the following semantics:
+ > If operation X is persisted, then all operations before X in the input operation sequence are persisted as well (and none after).
+
+Persisting operations is done using the `checkpoint()` function. It is also important to periodically call the `refresh()` function as it is the mechanism threads use to report forward progress to the system.
+
+Individual sessions (threads accessing FASTER) will persist a different number of operations. The most recently persisted serial number is returned by the `continue_session()` function and allows reasoning about which operations were (not) persisted. It is also the operation sequence number from which the thread should continue to provide operations after recovery. 
+
+A good demonstration of checkpointing/recovery can be found in `examples/sum_store_single.rs`. Try it out for yourself!
+```bash
+$ cargo run --example sum_store_single -- populate
+$ cargo run --example sum_store_single -- recover <checkpoint-token>
+```
 # Things to fix
 
 - [x] Fix so you can actually return the values from read

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,13 +15,13 @@ fn main() {
 
         // Upsert
         for i in 0..1000 {
-            let upsert = store.upsert(key0 + i, &(value0 + i));
+            let upsert = store.upsert(key0 + i, &(value0 + i), i);
             assert!(upsert == status::OK || upsert == status::PENDING);
         }
 
         // Read-Modify-Write
         for i in 0..1000 {
-            let rmw = store.rmw(key0 + i, &(5 as u64));
+            let rmw = store.rmw(key0 + i, &(5 as u64), i + 1000);
             assert!(rmw == status::OK || rmw == status::PENDING);
         }
 
@@ -30,7 +30,7 @@ fn main() {
         // Read
         for i in 0..1000 {
             // Note: need to provide type annotation for the Receiver
-            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i);
+            let (read, recv): (u8, Receiver<u64>) = store.read(key0 + i, i);
             assert!(read == status::OK || read == status::PENDING);
             let val = recv.recv().unwrap();
             assert_eq!(val, value0 + i + modification);

--- a/examples/custom_values.rs
+++ b/examples/custom_values.rs
@@ -35,13 +35,13 @@ fn main() {
         };
 
         // Upsert
-        let upsert = store.upsert(key, &value);
+        let upsert = store.upsert(key, &value, 1);
         assert!(upsert == status::OK || upsert == status::PENDING);
 
         assert!(store.size() > 0);
 
         // Note: need to provide type annotation for the Receiver
-        let (read, recv): (u8, Receiver<MyValue>) = store.read(key);
+        let (read, recv): (u8, Receiver<MyValue>) = store.read(key, 1);
         assert!(read == status::OK || read == status::PENDING);
         let val = recv.recv().unwrap();
         println!("Key: {}, Value: {:?}", key, val);

--- a/examples/sum_store_single.rs
+++ b/examples/sum_store_single.rs
@@ -4,12 +4,15 @@ use faster_kvs::*;
 use std::env;
 use std::sync::mpsc::Receiver;
 
-const TABLE_SIZE: u64 = 1 << 14;
+const TABLE_SIZE: u64  = 1 << 15;
 const LOG_SIZE: u64 = 17179869184;
-const NUM_OPS: u64 = 1 << 25;
+const NUM_OPS: u64 = 1  << 25;
+const NUM_UNIQUE_KEYS: u64 = 1 << 23;
 const REFRESH_INTERVAL: u64 = 1 << 8;
 const COMPLETE_PENDING_INTERVAL: u64 = 1 << 12;
 const CHECKPOINT_INTERVAL: u64 = 1 << 20;
+
+const STORAGE_DIR: &str = "single_threaded_recovery_storage";
 
 // More or less a copy of the single-threaded sum_store populate/recover example from FASTER
 
@@ -39,15 +42,14 @@ fn main() {
 }
 
 fn populate() -> () {
-    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage")) {
+    if let Ok(store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, STORAGE_DIR.to_string()) {
         // Populate Store
-        let value: u64 = 1000;
         let session = store.start_session();
         println!("Starting Session {}", session);
 
         for i in 0..NUM_OPS {
             let idx = i as u64;
-            store.upsert(idx, &value);
+            store.rmw(idx % NUM_UNIQUE_KEYS, 1);
 
             if (idx % CHECKPOINT_INTERVAL) == 0 {
                 let check = store.checkpoint().unwrap();
@@ -58,6 +60,24 @@ fn populate() -> () {
                 store.complete_pending(false);
             } else if (idx % REFRESH_INTERVAL) == 0 {
                 store.refresh();
+            }
+        }
+
+        println!("Ensuring values stored correctly");
+        let mut expected_results = Vec::with_capacity(NUM_UNIQUE_KEYS as usize);
+        expected_results.resize(NUM_UNIQUE_KEYS as usize, 0);
+        for i in 0..NUM_OPS {
+            let elem =  expected_results.get_mut((i % NUM_UNIQUE_KEYS) as usize).unwrap();
+            *elem += 1;
+        }
+
+        for i in 0..NUM_OPS {
+            let idx = i as u64;
+            let (status, recv)= store.read(idx % NUM_UNIQUE_KEYS);
+            if let Ok(val) = recv.recv() {
+                assert_eq!(val, *expected_results.get((idx % NUM_UNIQUE_KEYS) as usize).unwrap(), "Failed to read: {}", idx);
+            } else {
+                println!("Failure to read with status: {}, and key: {}", status, idx);
             }
         }
 
@@ -72,27 +92,40 @@ fn populate() -> () {
 
 fn recover(token: String) -> () {
     println!("Attempting to recover");
-    if let Ok(recover_store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, String::from("storage")) {
+    if let Ok(recover_store) = FasterKv::new(TABLE_SIZE, LOG_SIZE, STORAGE_DIR.to_string()) {
         match recover_store.recover(token.clone(), token.clone()) {
             Some(rec) => {
                 println!("Recover version: {}", rec.version);
                 println!("Recover status: {}", rec.status);
-                println!("{:?}", rec.session_ids);
+                println!("Recovered sessions: {:?}", rec.session_ids);
                 recover_store.continue_session(rec.session_ids.first().cloned().unwrap());
+
+                let mut expected_results = Vec::with_capacity(NUM_UNIQUE_KEYS as usize);
+                expected_results.resize(NUM_UNIQUE_KEYS as usize, 0);
+                for i in 0..NUM_OPS {
+                    let elem =  expected_results.get_mut((i % NUM_UNIQUE_KEYS) as usize).unwrap();
+                    *elem += 1;
+                }
+
                 println!("Verifying recovered values!");
-                let value: u64 = 1000;
+                let mut incorrect = 0;
                 for i in 0..NUM_OPS {
                     let idx = i as u64;
-                    let (status, recv): (u8, Receiver<u64>) = recover_store.read(idx);
+                    let (status, recv)= recover_store.read(idx % NUM_UNIQUE_KEYS);
                     if let Ok(val) = recv.recv() {
-                        assert_eq!(val, value);
+                        let expected = *expected_results.get((idx % NUM_UNIQUE_KEYS) as usize).unwrap();
+                        if expected != val {
+                            println!("Error recovering {}, expected {}, got {}", idx, expected, val);
+                            incorrect += 1;
+                        }
                     } else {
                         println!("Failure to read with status: {}, and key: {}", status, idx);
                     }
                 }
+                println!("{} incorrect recoveries", incorrect);
                 println!("Ok.....!");
                 recover_store.stop_session();
-            }
+            },
             None => println!("Recover operation failed"),
         }
     } else {

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -17,10 +17,10 @@ fn faster_check() {
     let key: u64 = 1;
     let value: u64 = 1337;
 
-    let upsert = store.upsert(key, &value);
+    let upsert = store.upsert(key, &value, 1);
     assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-    let rmw = store.rmw(key, &(5 as u64));
+    let rmw = store.rmw(key, &(5 as u64), 1);
     assert!(rmw == status::OK);
 
     assert!(store.size() > 0);
@@ -34,10 +34,10 @@ fn faster_read_inserted_value() {
     let key: u64 = 1;
     let value: u64 = 1337;
 
-    let upsert = store.upsert(key, &value);
+    let upsert = store.upsert(key, &value, 1);
     assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key);
+    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == value);
 }
@@ -49,7 +49,7 @@ fn faster_read_missing_value_recv_error() {
     let store = FasterKv::new(TABLE_SIZE, LOG_SIZE, dir_path).unwrap();
     let key: u64 = 1;
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key);
+    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
     assert!(res == status::NOT_FOUND);
     assert!(recv.recv().is_err());
 }
@@ -63,17 +63,17 @@ fn faster_rmw_changes_values() {
     let value: u64 = 1337;
     let modification: u64 = 100;
 
-    let upsert = store.upsert(key, &value);
+    let upsert = store.upsert(key, &value, 1);
     assert!((upsert == status::OK || upsert == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key);
+    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == value);
 
-    let rmw = store.rmw(key, &modification);
+    let rmw = store.rmw(key, &modification, 1);
     assert!((rmw == status::OK || rmw == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key);
+    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == value + modification);
 }
@@ -86,10 +86,10 @@ fn faster_rmw_without_upsert() {
     let key: u64 = 1;
     let modification: u64 = 100;
 
-    let rmw = store.rmw(key, &modification);
+    let rmw = store.rmw(key, &modification, 1);
     assert!((rmw == status::OK || rmw == status::PENDING) == true);
 
-    let (res, recv): (u8, Receiver<u64>) = store.read(key);
+    let (res, recv): (u8, Receiver<u64>) = store.read(key, 1);
     assert!(res == status::OK);
     assert!(recv.recv().unwrap() == modification);
 }
@@ -103,17 +103,17 @@ fn faster_rmw_string() {
     let value = String::from("Hello, ");
     let modification = String::from("World!");
 
-    let upsert = store.upsert(key, &value);
+    let upsert = store.upsert(key, &value, 1);
     assert!(upsert == status::OK || upsert == status::PENDING);
 
-    let (res, recv): (u8, Receiver<String>) = store.read(key);
+    let (res, recv): (u8, Receiver<String>) = store.read(key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), value);
 
-    let rmw = store.rmw(key, &modification);
+    let rmw = store.rmw(key, &modification, 1);
     assert!(rmw == status::OK || rmw == status::PENDING);
 
-    let (res, recv): (u8, Receiver<String>) = store.read(key);
+    let (res, recv): (u8, Receiver<String>) = store.read(key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), String::from("Hello, World!"));
 }
@@ -127,17 +127,17 @@ fn faster_rmw_vec() {
     let value = vec![0, 1, 2];
     let modification = vec![3, 4, 5];
 
-    let upsert = store.upsert(key, &value);
+    let upsert = store.upsert(key, &value, 1);
     assert!(upsert == status::OK || upsert == status::PENDING);
 
-    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(key);
+    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), value);
 
-    let rmw = store.rmw(key, &modification);
+    let rmw = store.rmw(key, &modification, 1);
     assert!(rmw == status::OK || rmw == status::PENDING);
 
-    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(key);
+    let (res, recv): (u8, Receiver<Vec<i32>>) = store.read(key, 1);
     assert_eq!(res, status::OK);
     assert_eq!(recv.recv().unwrap(), vec![0, 1, 2, 3, 4, 5]);
 }

--- a/tests/checkpoint_tests.rs
+++ b/tests/checkpoint_tests.rs
@@ -14,7 +14,7 @@ fn single_checkpoint() {
     let value: u64 = 100;
 
     for key in 0..1000 {
-        store.upsert(key as u64, &value);
+        store.upsert(key as u64, &value, key);
     }
 
     let checkpoint = store.checkpoint().unwrap();

--- a/tests/thread_tests.rs
+++ b/tests/thread_tests.rs
@@ -20,7 +20,7 @@ fn multi_threaded_test() {
     let modification: u64 = 30;
 
     for key in 0..ops {
-        store.upsert(key as u64, &initial_value);
+        store.upsert(key as u64, &initial_value, key);
     }
 
     let num_threads = 4;
@@ -32,7 +32,7 @@ fn multi_threaded_test() {
             let _session = store.start_session();
 
             for key in 0..ops {
-                store.rmw(key as u64, &modification);
+                store.rmw(key as u64, &modification, key);
             }
 
             // Make sure everything is completed
@@ -49,7 +49,7 @@ fn multi_threaded_test() {
 
     for key in 0..ops {
         let expected_value = initial_value + (modification * num_threads);
-        let (_res, recv): (u8, Receiver<u64>) = store.read(key as u64);
+        let (_res, recv): (u8, Receiver<u64>) = store.read(key, key);
         assert_eq!(recv.recv().unwrap(), expected_value);
     }
 }


### PR DESCRIPTION
What:
* have the user supply a monotonic serial number with operations
* fix the single_sum_store example (closes #2)
* update README

Why:
* FASTER requires operations to be tagged with a monotonic serial number in order to support CPR (for checkpointing)
* This is in keeping with FASTER design where user has control over order of operations and recovering from a fixed point in operation sequence